### PR TITLE
feat(clouddriver-lambda): Add configuration for tcpKeepAlive on the AWS Lambda client

### DIFF
--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/LambdaClientProvider.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/LambdaClientProvider.java
@@ -50,6 +50,7 @@ public class LambdaClientProvider {
 
     ClientConfiguration clientConfiguration = new ClientConfiguration();
     clientConfiguration.setSocketTimeout(operationsConfig.getInvokeTimeoutMs());
+    clientConfiguration.setUseTcpKeepAlive(operationsConfig.isTcpKeepAlive());
     // only override if non-negative, and can't just set to the negative default :(
     if (operationsConfig.getRetry().getRetries() >= 0) {
       clientConfiguration.setRetryPolicy(

--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/config/LambdaServiceConfig.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/config/LambdaServiceConfig.java
@@ -53,6 +53,7 @@ public class LambdaServiceConfig {
 
   private Retry retry = new Retry();
 
+  private boolean tcpKeepAlive = false;
   /**
    * Duplicated by the {@link
    * com.netflix.spinnaker.clouddriver.aws.AwsConfigurationProperties.ClientConfig} class and the

--- a/clouddriver-lambda/src/test/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/AbstractLambdaAtomicOperationTest.java
+++ b/clouddriver-lambda/src/test/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/AbstractLambdaAtomicOperationTest.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.lambda.deploy.ops;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -26,9 +27,13 @@ import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.lambda.deploy.description.InvokeLambdaFunctionDescription;
 import com.netflix.spinnaker.clouddriver.lambda.deploy.description.InvokeLambdaFunctionOutputDescription;
 import com.netflix.spinnaker.config.LambdaServiceConfig;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
 
 class AbstractLambdaAtomicOperationTest {
 
@@ -59,6 +64,7 @@ class AbstractLambdaAtomicOperationTest {
         .getAmazonLambda(any(), captureclientConfig.capture(), eq("someplace"));
     assertEquals(3, captureclientConfig.getValue().getMaxErrorRetry());
     assertEquals(50000, captureclientConfig.getValue().getSocketTimeout());
+    assertEquals(false, captureclientConfig.getValue().useTcpKeepAlive());
   }
 
   @Test
@@ -91,5 +97,49 @@ class AbstractLambdaAtomicOperationTest {
     //    assertEquals(4, captureclientConfig.getValue().getMaxErrorRetry());
     assertEquals(0, captureclientConfig.getValue().getMaxErrorRetry());
     assertEquals(300000, captureclientConfig.getValue().getSocketTimeout());
+  }
+
+  @Test
+  public void verifyLambdaClientSetsTcpKeepAlive() {
+    InvokeLambdaFunctionDescription desc = new InvokeLambdaFunctionDescription();
+    desc.setRegion("someplace");
+    NetflixAmazonCredentials creds = mock(NetflixAmazonCredentials.class);
+    when(creds.getLambdaEnabled()).thenReturn(true);
+    desc.setCredentials(creds);
+    AbstractLambdaAtomicOperation<
+            InvokeLambdaFunctionDescription, InvokeLambdaFunctionOutputDescription>
+        operation =
+            new AbstractLambdaAtomicOperation<>(desc, null) {
+
+              @Override
+              public InvokeLambdaFunctionOutputDescription operate(
+                  List<InvokeLambdaFunctionOutputDescription> priorOutputs) {
+                return null;
+              }
+            };
+    operation.operationsConfig = new LambdaServiceConfig();
+    operation.operationsConfig.setTcpKeepAlive(true);
+    operation.amazonClientProvider = mock(AmazonClientProvider.class);
+    ArgumentCaptor<ClientConfiguration> captureclientConfig =
+        ArgumentCaptor.forClass(ClientConfiguration.class);
+    operation.getLambdaClient();
+    verify(operation.amazonClientProvider)
+        .getAmazonLambda(any(), captureclientConfig.capture(), eq("someplace"));
+    assertEquals(true, captureclientConfig.getValue().useTcpKeepAlive());
+  }
+
+  @Test
+  void tcpKeepAliveShouldBindFromProperties() {
+    // Given
+    Map<String, String> props = new HashMap<>();
+    props.put("aws.lambda.tcpKeepAlive", "true");
+    // When
+    LambdaServiceConfig config =
+        new Binder(new MapConfigurationPropertySource(props))
+            .bind("aws.lambda", LambdaServiceConfig.class)
+            .get();
+
+    // Then
+    assertThat(config.isTcpKeepAlive()).isTrue();
   }
 }


### PR DESCRIPTION
For long running lambdas there is a network condition that mades clouddriver to lost the TCP connection after 350 seconds when invoking the function as explained on this blog post
https://aws.amazon.com/blogs/networking-and-content-delivery/implementing-long-running-tcp-connections-within-vpc-networking/
There are 2 parts for allowing this long running functions to be successfully invoked and retrieve the result:
Add sysctl configuration on the pod's security context
securityContext:
sysctls:
- name: "net.ipv4.tcp_keepalive_time"
value: "45"
- name: "net.ipv4.tcp_keepalive_intvl"
value: "45"
And enable TCP Keep alive on the lambda client configuration. This PR add that configuration.

aws:
lambda:
tcpKeepAlive: true
