### PR TITLE
fix(gitrepo): harden gitrepo artifact validation

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitJobExecutor.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitJobExecutor.java
@@ -36,6 +36,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 @Slf4j
@@ -44,6 +45,23 @@ public class GitJobExecutor {
   private static final String SSH_KEY_PWD_ENV_VAR = "SSH_KEY_PWD";
   private static final Pattern FULL_SHA_PATTERN = Pattern.compile("[0-9a-f]{40}");
   private static final Pattern SHORT_SHA_PATTERN = Pattern.compile("[0-9a-f]{7}");
+  // Valid git reference pattern: allows alphanumeric, hyphens, underscores, forward slashes, and
+  // dots
+  // but prevents command injection characters like semicolons, pipes, backticks, etc.
+  private static final Pattern VALID_GIT_REF_PATTERN = Pattern.compile("^[a-zA-Z0-9/_.-]+$");
+  // Valid path pattern: allows alphanumeric, hyphens, underscores, forward slashes, and dots
+  private static final Pattern VALID_PATH_PATTERN = Pattern.compile("^[a-zA-Z0-9/_.-]+$");
+
+  // TODO: Do we need to allow someone... to bypass this for ANY reason??
+  // Regex pattern from GeeksforGeeks covering common git URL formats
+  // https://www.geeksforgeeks.org/dsa/validate-git-repository-using-regular-expression/
+  // NOTE:  The above ALLOWS a file reference.  aka `git clone --local
+  // file:///path/to/source/folder` - which intentionally removing here.
+  // from the regex
+  private static final String GIT_URL_REGEX_PATTERN =
+      "((http|git|ssh|http(s))|(git@[\\w\\.]+))(:(\\/\\/)?)([\\w\\.@\\:\\/-~]+)(\\/)?";
+  private static final Pattern GIT_URL_PATTERN = Pattern.compile(GIT_URL_REGEX_PATTERN);
+
   private static Path genericAskPassBinary;
 
   @Getter private final GitRepoArtifactAccount account;
@@ -82,8 +100,47 @@ public class GitJobExecutor {
     askPassBinary = initAskPass();
   }
 
+  /**
+   * Validates that a git reference (branch, tag, or SHA) contains only safe characters to prevent
+   * command injection attacks.
+   *
+   * @param reference the git reference to validate
+   * @throws IllegalArgumentException if the reference contains unsafe characters
+   */
+  private void validateGitReference(String reference) {
+    if (ObjectUtils.isEmpty(reference)) {
+      throw new IllegalArgumentException("Git reference cannot be null or empty");
+    }
+    if (!VALID_GIT_REF_PATTERN.matcher(reference).matches()) {
+      throw new IllegalArgumentException(
+          "Git reference \""
+              + reference
+              + "\" contains invalid characters. Only alphanumeric characters, hyphens, underscores, forward slashes, and dots are allowed.");
+    }
+  }
+
+  /**
+   * Validates that a file path contains only safe characters to prevent command injection attacks.
+   *
+   * @param path the file path to validate
+   * @throws IllegalArgumentException if the path contains unsafe characters
+   */
+  private void validateFilePath(String path) {
+    if (StringUtils.isEmpty(path)) {
+      return; // Empty paths are acceptable in some contexts
+    }
+    if (!VALID_PATH_PATTERN.matcher(path).matches()) {
+      throw new IllegalArgumentException(
+          "File path \""
+              + path
+              + "\" contains invalid characters. Only alphanumeric characters, hyphens, underscores, forward slashes, and dots are allowed.");
+    }
+  }
+
   public void cloneOrPull(String repoUrl, String branch, Path localPath, String repoBasename)
       throws IOException {
+    validateRepoUrl(repoUrl);
+    validateGitReference(branch);
     File localPathFile = localPath.toFile();
     if (!localPathFile.exists()) {
       clone(repoUrl, branch, localPath, repoBasename);
@@ -118,6 +175,16 @@ public class GitJobExecutor {
     // localPath has "<repo>/.git" directory
 
     pull(repoUrl, branch, dotGitPath.getParent());
+  }
+
+  private void validateRepoUrl(String repoUrl) {
+    if (StringUtils.isEmpty(repoUrl)) {
+      throw new IllegalArgumentException("Repo URL cannot be null or empty");
+    }
+    if (!GIT_URL_PATTERN.matcher(repoUrl).matches()) {
+      throw new IllegalArgumentException(
+          "Git URL does not looked like a valid git reference.\"" + repoUrl);
+    }
   }
 
   private void clone(String repoUrl, String branch, Path destination, String repoBasename)
@@ -238,6 +305,8 @@ public class GitJobExecutor {
 
   public void archive(Path localClone, String branch, String subDir, Path outputFile)
       throws IOException {
+    validateGitReference(branch);
+    validateFilePath(subDir);
     String cmd =
         gitExecutable + " archive --format tgz --output " + outputFile.toString() + " " + branch;
 

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactAccount.java
@@ -20,6 +20,7 @@ import com.google.common.base.Strings;
 import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactAccount;
 import com.netflix.spinnaker.clouddriver.artifacts.config.TokenAuth;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.ParametersAreNullableByDefault;
 import lombok.Builder;
@@ -39,6 +40,34 @@ public class GitRepoArtifactAccount implements ArtifactAccount, TokenAuth {
   private final String sshPrivateKeyPassphraseCmd;
   private final String sshKnownHostsFilePath;
   private final boolean sshTrustUnknownHosts;
+  private final List<String> allowedHosts;
+
+  @Builder
+  @ParametersAreNullableByDefault
+  public GitRepoArtifactAccount(
+      String name,
+      String username,
+      String password,
+      String token,
+      String tokenFile,
+      String sshPrivateKeyFilePath,
+      String sshPrivateKeyPassphrase,
+      String sshPrivateKeyPassphraseCmd,
+      String sshKnownHostsFilePath,
+      boolean sshTrustUnknownHosts) {
+    this(
+        name,
+        username,
+        password,
+        token,
+        tokenFile,
+        sshPrivateKeyFilePath,
+        sshPrivateKeyPassphrase,
+        sshPrivateKeyPassphraseCmd,
+        sshKnownHostsFilePath,
+        sshTrustUnknownHosts,
+        List.of());
+  }
 
   @Builder
   @ConstructorBinding
@@ -53,7 +82,8 @@ public class GitRepoArtifactAccount implements ArtifactAccount, TokenAuth {
       String sshPrivateKeyPassphrase,
       String sshPrivateKeyPassphraseCmd,
       String sshKnownHostsFilePath,
-      boolean sshTrustUnknownHosts) {
+      boolean sshTrustUnknownHosts,
+      List<String> allowedHosts) {
     this.name = Strings.nullToEmpty(name);
     this.username = Strings.nullToEmpty(username);
     this.password = Strings.nullToEmpty(password);
@@ -64,5 +94,6 @@ public class GitRepoArtifactAccount implements ArtifactAccount, TokenAuth {
     this.sshPrivateKeyPassphraseCmd = Strings.nullToEmpty(sshPrivateKeyPassphraseCmd);
     this.sshKnownHostsFilePath = Strings.nullToEmpty(sshKnownHostsFilePath);
     this.sshTrustUnknownHosts = sshTrustUnknownHosts;
+    this.allowedHosts = allowedHosts;
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactConfiguration.java
@@ -50,7 +50,9 @@ class GitRepoArtifactConfiguration {
             a -> {
               try {
                 return new GitRepoArtifactCredentials(
-                    new GitJobExecutor(a, jobExecutor, gitExecutable), gitRepoFileSystem);
+                    new GitJobExecutor(a, jobExecutor, gitExecutable),
+                    gitRepoFileSystem,
+                    a.getAllowedHosts());
               } catch (IOException e) {
                 log.warn("Failure instantiating git artifact account {}: ", a, e);
                 return null;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactCredentials.java
@@ -26,8 +26,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
@@ -44,11 +46,14 @@ public class GitRepoArtifactCredentials implements ArtifactCredentials {
 
   private final GitJobExecutor executor;
   private final GitRepoFileSystem gitRepoFileSystem;
+  private final List<String> allowedHosts;
 
-  public GitRepoArtifactCredentials(GitJobExecutor executor, GitRepoFileSystem gitRepoFileSystem) {
+  public GitRepoArtifactCredentials(
+      GitJobExecutor executor, GitRepoFileSystem gitRepoFileSystem, List<String> allowedHosts) {
     this.executor = executor;
     this.gitRepoFileSystem = gitRepoFileSystem;
     this.name = this.executor.getAccount().getName();
+    this.allowedHosts = allowedHosts;
   }
 
   @Override
@@ -59,6 +64,7 @@ public class GitRepoArtifactCredentials implements ArtifactCredentials {
   @Override
   public InputStream download(Artifact artifact) throws IOException {
     String repoUrl = artifact.getReference();
+    validateHostIsAlllowedHost(repoUrl);
     String subPath = artifactSubPath(artifact);
     String branch = artifactVersion(artifact);
     Path stagingPath = gitRepoFileSystem.getLocalClonePath(repoUrl, branch);
@@ -76,6 +82,61 @@ public class GitRepoArtifactCredentials implements ArtifactCredentials {
               + ").",
           e);
     }
+  }
+
+  private void validateHostIsAlllowedHost(@Nullable String repoUrl)
+      throws IllegalArgumentException {
+    // If allowedHosts is null or empty, allow all hosts
+    if (allowedHosts == null || allowedHosts.isEmpty()) {
+      log.warn(
+          "No allow hosts set on the account "
+              + executor.getAccount().getName()
+              + " - should set some limits on these accounts on which hosts it can connect to");
+      return;
+    }
+    String hostname = extractHostname(repoUrl);
+
+    // Check if hostname matches any allowed host (case-insensitive)
+    // Supports both exact matches and subdomain matches
+    boolean isAllowed =
+        allowedHosts.stream()
+            .anyMatch(
+                allowedHost ->
+                    allowedHost.equalsIgnoreCase(hostname)
+                        || hostname.endsWith("." + allowedHost.toLowerCase()));
+
+    if (!isAllowed) {
+      throw new IllegalArgumentException(
+          "Repository host '" + hostname + "' is not in the allowed hosts list: " + allowedHosts);
+    }
+  }
+
+  private String extractHostname(@Nullable String repoUrl) {
+    if (Strings.isNullOrEmpty(repoUrl)) {
+      throw new IllegalArgumentException("Repository URL cannot be null or empty");
+    }
+
+    // Handle git@ style URLs (e.g., git@github.com:user/repo.git)
+    if (repoUrl.startsWith("git@")) {
+      int colonIndex = repoUrl.indexOf(':', 4);
+      if (colonIndex > 0) {
+        return repoUrl.substring(4, colonIndex).toLowerCase();
+      }
+      throw new IllegalArgumentException("Invalid git@ URL format: " + repoUrl);
+    }
+
+    // Handle standard URLs (http, https, git, ssh)
+    try {
+      java.net.URI uri = new java.net.URI(repoUrl);
+      String host = uri.getHost();
+      if (host != null) {
+        return host.toLowerCase();
+      }
+    } catch (java.net.URISyntaxException e) {
+      throw new IllegalArgumentException("Unable to parse repository URL: " + repoUrl, e);
+    }
+
+    throw new IllegalArgumentException("Unable to extract hostname from URL: " + repoUrl);
   }
 
   @NotNull

--- a/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitJobExecutorSecurityTest.java
+++ b/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitJobExecutorSecurityTest.java
@@ -1,0 +1,420 @@
+/*
+ * Copyright 2026 McIntosh.farm
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.gitRepo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.netflix.spinnaker.clouddriver.jobs.JobExecutor;
+import com.netflix.spinnaker.clouddriver.jobs.JobResult;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.junitpioneer.jupiter.TempDirectory;
+
+/**
+ * Security tests for GitJobExecutor to ensure proper input validation and prevention of command
+ * injection attacks.
+ */
+@ExtendWith({TempDirectory.class})
+class GitJobExecutorSecurityTest {
+
+  private GitJobExecutor gitJobExecutor;
+
+  @TempDir Path tempDir;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    JobExecutor mockJobExecutor;
+    mockJobExecutor = mock(JobExecutor.class);
+
+    // Mock successful job execution
+    when(mockJobExecutor.runJob(any()))
+        .thenReturn(
+            JobResult.<String>builder().result(JobResult.Result.SUCCESS).output("success").build());
+
+    GitRepoArtifactAccount account = GitRepoArtifactAccount.builder().name("test-account").build();
+
+    gitJobExecutor = new GitJobExecutor(account, mockJobExecutor, "git");
+  }
+
+  // Tests for valid git references
+  @Test
+  @DisplayName("Should accept valid branch names")
+  void shouldAcceptValidBranchNames() throws IOException {
+    Path localPath = tempDir.resolve("clone");
+    Files.createDirectories(localPath);
+
+    assertDoesNotThrow(
+        () -> gitJobExecutor.cloneOrPull("http://example.com/repo.git", "main", localPath, "repo"));
+    assertDoesNotThrow(
+        () ->
+            gitJobExecutor.cloneOrPull(
+                "http://api.github.com/example/repo.git", "main", localPath, "repo"));
+    assertDoesNotThrow(
+        () ->
+            gitJobExecutor.cloneOrPull(
+                "http://example.com/repo.git", "feature/new-feature", localPath, "repo"));
+    assertDoesNotThrow(
+        () ->
+            gitJobExecutor.cloneOrPull(
+                "http://example.com/repo.git", "release-1.0", localPath, "repo"));
+    assertDoesNotThrow(
+        () ->
+            gitJobExecutor.cloneOrPull("http://example.com/repo.git", "v1.2.3", localPath, "repo"));
+  }
+
+  // Tests for valid git references
+  @Test
+  @DisplayName("Verify a set of common URL patterns are valid.")
+  void checkSomeCommonUrlPatterns() throws IOException {
+    Path localPath = tempDir.resolve("clone");
+    Files.createDirectories(localPath);
+    String[] validUrls = {
+      "https://github.com/repo.git",
+      "https://gitlab.com/repo.git",
+      "https://bitbucket.org/repo.git",
+      "https://internal.company.com/repo.git",
+      "https://janedoe:password@example.com/project/repo.git",
+      "https://localhost:3000/project/repo" // gitea where a .git extension is NOT needed
+    };
+
+    for (String url : validUrls) {
+      assertDoesNotThrow(() -> gitJobExecutor.cloneOrPull(url, "main", localPath, "repo"));
+    }
+  }
+
+  @Test
+  @DisplayName("Should accept valid full SHA commit hashes")
+  void shouldAcceptValidFullSha() throws IOException {
+    Path localPath = tempDir.resolve("clone");
+    Files.createDirectories(localPath);
+
+    String validFullSha = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0";
+    assertDoesNotThrow(
+        () ->
+            gitJobExecutor.cloneOrPull(
+                "http://example.com/repo.git", validFullSha, localPath, "repo"));
+  }
+
+  @Test
+  @DisplayName("Should accept valid short SHA commit hashes")
+  void shouldAcceptValidShortSha() throws IOException {
+    Path localPath = tempDir.resolve("clone");
+    Files.createDirectories(localPath);
+
+    String validShortSha = "a1b2c3d";
+    assertDoesNotThrow(
+        () ->
+            gitJobExecutor.cloneOrPull(
+                "http://example.com/repo.git", validShortSha, localPath, "repo"));
+  }
+
+  @Test
+  @DisplayName("Should accept valid subdirectory paths")
+  void shouldAcceptValidSubdirectoryPaths() throws IOException {
+    Path localClone = tempDir.resolve("repo");
+    Path outputFile = tempDir.resolve("output.tgz");
+    Files.createDirectories(localClone.resolve(".git"));
+
+    assertDoesNotThrow(
+        () -> gitJobExecutor.archive(localClone, "main", "src/main/java", outputFile));
+    assertDoesNotThrow(() -> gitJobExecutor.archive(localClone, "main", "docs/api", outputFile));
+    assertDoesNotThrow(() -> gitJobExecutor.archive(localClone, "main", "config.yml", outputFile));
+  }
+
+  // Tests for command injection attempts
+  @Test
+  @DisplayName("Should reject branch names with semicolons (command injection)")
+  void shouldRejectBranchNamesWithSemicolons() {
+    Path localPath = tempDir.resolve("clone");
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                gitJobExecutor.cloneOrPull(
+                    "http://example.com/repo.git", "main; rm -rf /", localPath, "repo"));
+
+    assertContainsInvalidCharactersMessage(exception);
+  }
+
+  @Test
+  @DisplayName("Should reject branch names with pipes (command injection)")
+  void shouldRejectBranchNamesWithPipes() {
+    Path localPath = tempDir.resolve("clone");
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                gitJobExecutor.cloneOrPull(
+                    "http://example.com/repo.git", "main | cat /etc/passwd", localPath, "repo"));
+
+    assertContainsInvalidCharactersMessage(exception);
+  }
+
+  @Test
+  @DisplayName("Should reject branch names with backticks (command injection)")
+  void shouldRejectBranchNamesWithBackticks() {
+    Path localPath = tempDir.resolve("clone");
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                gitJobExecutor.cloneOrPull(
+                    "http://example.com/repo.git", "main`whoami`", localPath, "repo"));
+
+    assertContainsInvalidCharactersMessage(exception);
+  }
+
+  @Test
+  @DisplayName("Should reject branch names with dollar signs (command injection)")
+  void shouldRejectBranchNamesWithDollarSigns() {
+    Path localPath = tempDir.resolve("clone");
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                gitJobExecutor.cloneOrPull(
+                    "http://example.com/repo.git", "main$(whoami)", localPath, "repo"));
+
+    assertContainsInvalidCharactersMessage(exception);
+  }
+
+  @Test
+  @DisplayName("Should reject branch names with ampersands (command injection)")
+  void shouldRejectBranchNamesWithAmpersands() {
+    Path localPath = tempDir.resolve("clone");
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                gitJobExecutor.cloneOrPull(
+                    "http://example.com/repo.git", "main && curl evil.com", localPath, "repo"));
+
+    assertContainsInvalidCharactersMessage(exception);
+  }
+
+  @Test
+  @DisplayName("Should reject branch names with newlines (command injection)")
+  void shouldRejectBranchNamesWithNewlines() {
+    Path localPath = tempDir.resolve("clone");
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                gitJobExecutor.cloneOrPull(
+                    "http://example.com/repo.git", "main\nwhoami", localPath, "repo"));
+
+    assertContainsInvalidCharactersMessage(exception);
+  }
+
+  @Test
+  @DisplayName("Should reject branch names with spaces (potential injection)")
+  void shouldRejectBranchNamesWithSpaces() {
+    Path localPath = tempDir.resolve("clone");
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                gitJobExecutor.cloneOrPull(
+                    "http://example.com/repo.git", "main branch", localPath, "repo"));
+
+    assertContainsInvalidCharactersMessage(exception);
+  }
+
+  @Test
+  @DisplayName("Should reject branch names with redirection operators")
+  void shouldRejectBranchNamesWithRedirection() {
+    Path localPath = tempDir.resolve("clone");
+
+    IllegalArgumentException exception1 =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                gitJobExecutor.cloneOrPull(
+                    "http://example.com/repo.git", "main > /tmp/pwned", localPath, "repo"));
+
+    assertContainsInvalidCharactersMessage(exception1);
+
+    IllegalArgumentException exception2 =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                gitJobExecutor.cloneOrPull(
+                    "http://example.com/repo.git", "main < /etc/passwd", localPath, "repo"));
+
+    assertContainsInvalidCharactersMessage(exception2);
+  }
+
+  @Test
+  @DisplayName("Should reject subdirectory paths with command injection")
+  void shouldRejectSubdirectoryPathsWithInjection() throws IOException {
+    Path localClone = tempDir.resolve("repo");
+    Path outputFile = tempDir.resolve("output.tgz");
+    Files.createDirectories(localClone.resolve(".git"));
+
+    IllegalArgumentException exception1 =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> gitJobExecutor.archive(localClone, "main", "src; rm -rf /", outputFile));
+
+    assertContainsInvalidCharactersMessage(exception1);
+
+    IllegalArgumentException exception2 =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> gitJobExecutor.archive(localClone, "main", "src | whoami", outputFile));
+
+    assertContainsInvalidCharactersMessage(exception2);
+
+    IllegalArgumentException exception3 =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> gitJobExecutor.archive(localClone, "main", "src`id`", outputFile));
+
+    assertContainsInvalidCharactersMessage(exception3);
+  }
+
+  @Test
+  @DisplayName("Should reject null or empty branch names")
+  void shouldRejectNullOrEmptyBranchNames() {
+    Path localPath = tempDir.resolve("clone");
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> gitJobExecutor.cloneOrPull("http://example.com/repo.git", null, localPath, "repo"));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> gitJobExecutor.cloneOrPull("http://example.com/repo.git", "", localPath, "repo"));
+  }
+
+  @Test
+  @DisplayName("Should reject when someone tries to use a repo URL to inject bad creds")
+  void blowUPWhenBadRepoUrlIsIn() {
+    Path localPath = tempDir.resolve("clone");
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            gitJobExecutor.cloneOrPull(
+                "http://example.com/repo.git; cat /etc/passwd > /tmp/bad-actor.txt",
+                "main",
+                localPath,
+                "repo"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            gitJobExecutor.cloneOrPull(
+                "http://example.com/repo.git$(echo 'bad' > /tmp/bad-actor.txt)",
+                "main",
+                localPath,
+                "repo"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            gitJobExecutor.cloneOrPull(
+                "http://$(cat /etc/passwd):username@example.com/repo.git",
+                "main",
+                localPath,
+                "repo"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            gitJobExecutor.cloneOrPull(
+                "http://username:`cat /etc/passwd`@example.com/repo.git",
+                "main",
+                localPath,
+                "repo"));
+  }
+
+  @Test
+  @DisplayName("Should reject branch names with other special characters")
+  void shouldRejectBranchNamesWithSpecialCharacters() {
+    Path localPath = tempDir.resolve("clone");
+
+    String[] invalidBranches = {
+      "main@{evil}",
+      "main*",
+      "main?query",
+      "main#anchor",
+      "main!important",
+      "main%evil",
+      "main(evil)",
+      "main[evil]",
+      "main{evil}",
+      "main'evil",
+      "main\"evil",
+      "main\\evil"
+    };
+
+    for (String branch : invalidBranches) {
+      assertThrows(
+          IllegalArgumentException.class,
+          () ->
+              gitJobExecutor.cloneOrPull("http://example.com/repo.git", branch, localPath, "repo"),
+          "Should reject branch: " + branch);
+    }
+  }
+
+  @Test
+  @DisplayName("Should validate branch in archive method")
+  void shouldValidateBranchInArchiveMethod() throws IOException {
+    Path localClone = tempDir.resolve("repo");
+    Path outputFile = tempDir.resolve("output.tgz");
+    Files.createDirectories(localClone.resolve(".git"));
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> gitJobExecutor.archive(localClone, "main; rm -rf /", "src", outputFile));
+
+    assertContainsInvalidCharactersMessage(exception);
+  }
+
+  @Test
+  @DisplayName("Should accept empty subdirectory path")
+  void shouldAcceptEmptySubdirectoryPath() throws IOException {
+    Path localClone = tempDir.resolve("repo");
+    Path outputFile = tempDir.resolve("output.tgz");
+    Files.createDirectories(localClone.resolve(".git"));
+
+    assertDoesNotThrow(() -> gitJobExecutor.archive(localClone, "main", "", outputFile));
+    assertDoesNotThrow(() -> gitJobExecutor.archive(localClone, "main", null, outputFile));
+  }
+
+  private void assertContainsInvalidCharactersMessage(IllegalArgumentException exception) {
+    assertThat(exception.getMessage())
+        .withFailMessage("Exception should let the user know there was a problem")
+        .containsAnyOf("contains invalid characters", "cannot be null or empty");
+  }
+}

--- a/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactCredentialsTest.java
+++ b/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactCredentialsTest.java
@@ -1,0 +1,379 @@
+/*
+ * Copyright 2026 McIntosh.farm
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.gitRepo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for GitRepoArtifactCredentials to verify URL validation against allowedHosts list when
+ * invoking the download method.
+ */
+class GitRepoArtifactCredentialsTest {
+  GitJobExecutor mockExecutor;
+  GitRepoFileSystem mockFileSystem;
+
+  @BeforeEach
+  void setUp() {
+    mockExecutor = mock(GitJobExecutor.class);
+    mockFileSystem = mock(GitRepoFileSystem.class);
+    GitRepoArtifactAccount mockAccount =
+        new GitRepoArtifactAccount(
+            "mockAccount", null, null, null, null, null, null, null, null, false);
+    when(mockExecutor.getAccount()).thenReturn(mockAccount);
+    mockFileSystem = mock(GitRepoFileSystem.class);
+  }
+
+  @Test
+  @DisplayName("Should allow download when URL host matches allowedHosts list.  ")
+  void shouldAllowDownloadWhenHostMatches() throws Exception {
+    List<String> allowedHosts = Arrays.asList("github.com", "gitlab.com", "bitbucket.org");
+
+    GitRepoArtifactCredentials credentials =
+        new GitRepoArtifactCredentials(mockExecutor, mockFileSystem, allowedHosts);
+
+    Artifact artifact =
+        Artifact.builder()
+            .reference("https://github.com/spinnaker/clouddriver.git")
+            .version("main")
+            .build();
+    validateHostVerificationByVerifyingALaterException(credentials, artifact);
+  }
+
+  @Test
+  @DisplayName("Should allow download when URL host with subdomain matches allowedHosts")
+  void shouldAllowDownloadWhenSubdomainMatches() throws Exception {
+    List<String> allowedHosts = Collections.singletonList("github.com");
+
+    GitRepoArtifactCredentials credentials =
+        new GitRepoArtifactCredentials(mockExecutor, mockFileSystem, allowedHosts);
+
+    Artifact artifact =
+        Artifact.builder()
+            .reference("https://api.github.com/repos/spinnaker/clouddriver.git")
+            .version("main")
+            .build();
+    validateHostVerificationByVerifyingALaterException(credentials, artifact);
+  }
+
+  @Test
+  @DisplayName("Should reject download when URL host is not in allowedHosts list")
+  void shouldRejectDownloadWhenHostNotInList() {
+    List<String> allowedHosts = Arrays.asList("github.com", "gitlab.com");
+
+    GitRepoArtifactCredentials credentials =
+        new GitRepoArtifactCredentials(mockExecutor, mockFileSystem, allowedHosts);
+
+    Artifact artifact =
+        Artifact.builder().reference("https://evil.com/malicious/repo.git").version("main").build();
+
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> credentials.download(artifact));
+
+    assertThat(exception.getMessage()).containsIgnoringCase("host");
+  }
+
+  @Test
+  @DisplayName("Should allow download when allowedHosts list is null/empty")
+  void allowAnyHostIfAllowedHostsIsEmpty() throws Exception {
+    Artifact artifact =
+        Artifact.builder()
+            .reference("https://github.com/spinnaker/clouddriver.git")
+            .version("main")
+            .build();
+    when(mockFileSystem.tryTimedLock(anyString(), anyString())).thenReturn(true);
+    when(mockFileSystem.getCloneWaitLockTimeoutSec()).thenReturn(60);
+    when(mockFileSystem.getLocalClonePath(anyString(), anyString()))
+        .thenReturn(Files.createTempDirectory("gitrepoartifacttests"));
+
+    validateHostVerificationByVerifyingALaterException(
+        new GitRepoArtifactCredentials(mockExecutor, mockFileSystem, Collections.emptyList()),
+        artifact);
+    validateHostVerificationByVerifyingALaterException(
+        new GitRepoArtifactCredentials(mockExecutor, mockFileSystem, null), artifact);
+  }
+
+  @Test
+  @DisplayName("Should handle SSH URLs for host validation")
+  void shouldHandleSshUrls() throws Exception {
+    List<String> allowedHosts = Collections.singletonList("github.com");
+
+    GitRepoArtifactCredentials credentials =
+        new GitRepoArtifactCredentials(mockExecutor, mockFileSystem, allowedHosts);
+
+    Artifact artifact =
+        Artifact.builder()
+            .reference("git@github.com:spinnaker/clouddriver.git")
+            .version("main")
+            .build();
+
+    validateHostVerificationByVerifyingALaterException(credentials, artifact);
+  }
+
+  @Test
+  @DisplayName("Should reject SSH URLs when host is not in allowedHosts")
+  void shouldRejectSshUrlsWhenHostNotAllowed() {
+    List<String> allowedHosts = Collections.singletonList("github.com");
+
+    GitRepoArtifactCredentials credentials =
+        new GitRepoArtifactCredentials(mockExecutor, mockFileSystem, allowedHosts);
+
+    Artifact artifact =
+        Artifact.builder().reference("git@evil.com:malicious/repo.git").version("main").build();
+
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> credentials.download(artifact));
+
+    assertThat(exception.getMessage()).containsIgnoringCase("host");
+  }
+
+  @Test
+  @DisplayName("Should handle git:// protocol URLs")
+  void shouldHandleGitProtocolUrls() throws Exception {
+    List<String> allowedHosts = Collections.singletonList("github.com");
+
+    GitRepoArtifactCredentials credentials =
+        new GitRepoArtifactCredentials(mockExecutor, mockFileSystem, allowedHosts);
+
+    Artifact artifact =
+        Artifact.builder()
+            .reference("git://github.com/spinnaker/clouddriver.git")
+            .version("main")
+            .build();
+
+    validateHostVerificationByVerifyingALaterException(credentials, artifact);
+  }
+
+  @Test
+  @DisplayName("Should reject git:// protocol URLs when host not allowed")
+  void shouldRejectGitProtocolUrlsWhenHostNotAllowed() {
+    List<String> allowedHosts = Collections.singletonList("github.com");
+
+    GitRepoArtifactCredentials credentials =
+        new GitRepoArtifactCredentials(mockExecutor, mockFileSystem, allowedHosts);
+
+    Artifact artifact =
+        Artifact.builder().reference("git://evil.com/malicious/repo.git").version("main").build();
+
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> credentials.download(artifact));
+
+    assertThat(exception.getMessage()).containsIgnoringCase("host");
+  }
+
+  @Test
+  @DisplayName("Should handle URLs with ports")
+  void shouldHandleUrlsWithPorts() throws Exception {
+    List<String> allowedHosts = Collections.singletonList("gitlab.internal.com");
+
+    GitRepoArtifactCredentials credentials =
+        new GitRepoArtifactCredentials(mockExecutor, mockFileSystem, allowedHosts);
+
+    Artifact artifact =
+        Artifact.builder()
+            .reference("https://gitlab.internal.com:8443/spinnaker/clouddriver.git")
+            .version("main")
+            .build();
+
+    validateHostVerificationByVerifyingALaterException(credentials, artifact);
+  }
+
+  @Test
+  @DisplayName("Should handle URLs with authentication in URL")
+  void shouldHandleUrlsWithAuth() throws Exception {
+    List<String> allowedHosts = Collections.singletonList("github.com");
+
+    GitRepoArtifactCredentials credentials =
+        new GitRepoArtifactCredentials(mockExecutor, mockFileSystem, allowedHosts);
+
+    Artifact artifact =
+        Artifact.builder()
+            .reference("https://user:token@github.com/spinnaker/clouddriver.git")
+            .version("main")
+            .build();
+
+    validateHostVerificationByVerifyingALaterException(credentials, artifact);
+  }
+
+  @Test
+  @DisplayName("Should reject URL with invalid host even with auth in URL")
+  void shouldRejectInvalidHostWithAuth() {
+    List<String> allowedHosts = Collections.singletonList("github.com");
+
+    GitRepoArtifactCredentials credentials =
+        new GitRepoArtifactCredentials(mockExecutor, mockFileSystem, allowedHosts);
+
+    Artifact artifact =
+        Artifact.builder()
+            .reference("https://user:token@evil.com/malicious/repo.git")
+            .version("main")
+            .build();
+
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> credentials.download(artifact));
+
+    assertThat(exception.getMessage()).containsIgnoringCase("host");
+  }
+
+  @Test
+  @DisplayName("Should be case-insensitive for host matching")
+  void shouldBeCaseInsensitiveForHostMatching() throws Exception {
+    List<String> allowedHosts = Collections.singletonList("GitHub.COM");
+
+    GitRepoArtifactCredentials credentials =
+        new GitRepoArtifactCredentials(mockExecutor, mockFileSystem, allowedHosts);
+
+    Artifact artifact =
+        Artifact.builder()
+            .reference("https://github.com/spinnaker/clouddriver.git")
+            .version("main")
+            .build();
+
+    validateHostVerificationByVerifyingALaterException(credentials, artifact);
+  }
+
+  @Test
+  @DisplayName("Should handle malformed URLs gracefully")
+  void shouldHandleMalformedUrls() {
+    List<String> allowedHosts = Collections.singletonList("github.com");
+
+    GitRepoArtifactCredentials credentials =
+        new GitRepoArtifactCredentials(mockExecutor, mockFileSystem, allowedHosts);
+
+    Artifact artifact = Artifact.builder().reference("not-a-valid-url").version("main").build();
+
+    assertThrows(IllegalArgumentException.class, () -> credentials.download(artifact));
+  }
+
+  @Test
+  @DisplayName("Should reject when URL reference is null")
+  void shouldRejectWhenReferenceIsNull() {
+    List<String> allowedHosts = Collections.singletonList("github.com");
+
+    GitRepoArtifactCredentials credentials =
+        new GitRepoArtifactCredentials(mockExecutor, mockFileSystem, allowedHosts);
+
+    Artifact artifact = Artifact.builder().version("main").build();
+
+    assertThrows(IllegalArgumentException.class, () -> credentials.download(artifact));
+  }
+
+  @Test
+  @DisplayName("Should reject when URL reference is empty")
+  void shouldRejectWhenReferenceIsEmpty() {
+    List<String> allowedHosts = Collections.singletonList("github.com");
+
+    GitRepoArtifactCredentials credentials =
+        new GitRepoArtifactCredentials(mockExecutor, mockFileSystem, allowedHosts);
+
+    Artifact artifact = Artifact.builder().reference("").version("main").build();
+
+    assertThrows(IllegalArgumentException.class, () -> credentials.download(artifact));
+  }
+
+  @Test
+  @DisplayName("Should handle SSH URLs with ssh:// protocol")
+  void shouldHandleSshProtocolUrls() throws Exception {
+    List<String> allowedHosts = Collections.singletonList("github.com");
+
+    GitRepoArtifactCredentials credentials =
+        new GitRepoArtifactCredentials(mockExecutor, mockFileSystem, allowedHosts);
+
+    Artifact artifact =
+        Artifact.builder()
+            .reference("ssh://git@github.com/spinnaker/clouddriver.git")
+            .version("main")
+            .build();
+
+    validateHostVerificationByVerifyingALaterException(credentials, artifact);
+  }
+
+  @Test
+  @DisplayName("Should support multiple allowed hosts")
+  void shouldSupportMultipleAllowedHosts() throws Exception {
+    List<String> allowedHosts =
+        Arrays.asList("github.com", "gitlab.com", "bitbucket.org", "internal.company.com");
+
+    GitRepoArtifactCredentials credentials =
+        new GitRepoArtifactCredentials(mockExecutor, mockFileSystem, allowedHosts);
+
+    // Test each allowed host
+    String[] validUrls = {
+      "https://github.com/repo.git",
+      "https://gitlab.com/repo.git",
+      "https://bitbucket.org/repo.git",
+      "https://internal.company.com/repo.git"
+    };
+
+    for (String url : validUrls) {
+      validateHostVerificationByVerifyingALaterException(
+          credentials, Artifact.builder().reference(url).version("main").build());
+    }
+  }
+
+  @Test
+  @DisplayName("Should reject host not in multi-host allowedHosts list")
+  void shouldRejectHostNotInMultiHostList() {
+    List<String> allowedHosts = Arrays.asList("github.com", "gitlab.com", "bitbucket.org");
+
+    GitRepoArtifactCredentials credentials =
+        new GitRepoArtifactCredentials(mockExecutor, mockFileSystem, allowedHosts);
+
+    Artifact artifact =
+        Artifact.builder().reference("https://not-allowed.com/repo.git").version("main").build();
+
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> credentials.download(artifact));
+
+    assertThat(exception.getMessage()).containsIgnoringCase("host");
+  }
+
+  /*
+  This is a TOUCH goofy that we throw an exception.  This is b/c the credentials mixes file handling in the code that
+  does validation.  SO we verify WHICH exception is thrown by triggering a "lock failure" which happens AFTER
+  host validation completes.
+   */
+  private void validateHostVerificationByVerifyingALaterException(
+      GitRepoArtifactCredentials credentials, Artifact artifact)
+      throws InterruptedException, IOException {
+    // Mock the filesystem and executor behavior to avoid actual git operations
+    when(mockFileSystem.tryTimedLock(anyString(), anyString())).thenReturn(false);
+    when(mockFileSystem.getLocalClonePath(anyString(), anyString()))
+        .thenReturn(Files.createTempDirectory("gitrepoartifacttests"));
+
+    // This should throw IOException due to lock timeout, but NOT IllegalArgumentException for
+    // host validation
+    IOException exception = assertThrows(IOException.class, () -> credentials.download(artifact));
+
+    assertThat(exception.getMessage())
+        .contains("Timeout waiting to acquire file system lock")
+        .doesNotContain("host");
+  }
+}


### PR DESCRIPTION
Backport spinnaker/spinnaker@184dd04 to validate git refs, subPaths, and repository URLs before invoking git, and optionally restrict downloads to an account-level allowed host list.

Upstream: https://github.com/spinnaker/spinnaker/commit/184dd04bb53d77688c6588b20137c0f03e37f64d
