### PR TITLE
fix(tagger): Fix the tag namer. 

### DIFF
--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/LambdaCachingAgent.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/LambdaCachingAgent.java
@@ -49,6 +49,7 @@ import com.netflix.spinnaker.clouddriver.core.limits.ServiceLimitConfiguration;
 import com.netflix.spinnaker.clouddriver.lambda.cache.Keys;
 import com.netflix.spinnaker.clouddriver.lambda.names.LambdaResource;
 import com.netflix.spinnaker.clouddriver.lambda.names.LambdaResourceFunction;
+import com.netflix.spinnaker.clouddriver.lambda.names.LambdaTagNamer;
 import com.netflix.spinnaker.clouddriver.lambda.service.LambdaService;
 import com.netflix.spinnaker.clouddriver.names.NamerRegistry;
 import com.netflix.spinnaker.config.LambdaServiceConfig;
@@ -93,10 +94,7 @@ public class LambdaCachingAgent implements CachingAgent, AccountAware, OnDemandA
         region,
         lambdaServiceConfig,
         serviceLimitConfiguration,
-        NamerRegistry.lookup()
-            .withProvider(AmazonCloudProvider.ID)
-            .withAccount(account.getName())
-            .withResource(LambdaResource.class));
+        new LambdaTagNamer()));
   }
 
   @VisibleForTesting

--- a/clouddriver-lambda/src/test/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/LambdaCachingAgentTest.java
+++ b/clouddriver-lambda/src/test/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/LambdaCachingAgentTest.java
@@ -69,8 +69,7 @@ public class LambdaCachingAgentTest {
             netflixAmazonCredentials,
             REGION,
             config,
-            serviceLimitConfiguration,
-            new LambdaTagNamer());
+            serviceLimitConfiguration);
   }
 
   @Test


### PR DESCRIPTION
The tag namer lookup depends on credentials parsing ALSO setting the tag namer on an account by account basis.  Let's just fix this to ALWAYS use the lambda tag namer vs. allowing a "default" overrider that uses the name pattern.    We already default to the Frigga in the case of no tags being set.